### PR TITLE
Upgrade OTel deps and harden semconv handling

### DIFF
--- a/.changeset/green-queens-admire.md
+++ b/.changeset/green-queens-admire.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/otel-cf-workers': minor
+---
+
+Upgrade OpenTelemetry dependencies to current releases, move unstable semconv usage behind a local compatibility layer, and migrate emitted database telemetry from `db.system` to `db.system.name` while retaining `rpc.message.id`.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10.23.0
       - name: Use Node.js LTS
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10.23.0
       - name: Use Node.js LTS
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10.23.0
       - name: Use Node.js LTS
         uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ examples/worker/.dev.vars
 */.dev.vars
 examples/queue/.dev.vars
 versions.json
+**/.wrangler/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An OpenTelemetry compatible library for instrumenting and exporting traces from 
 ## Getting started
 
 ```bash
-npm install @microlabs/otel-cf-workers @opentelemetry/api
+npm install @pydantic/otel-cf-workers @opentelemetry/api@^1.9.0
 ```
 
 > [!IMPORTANT]
@@ -21,7 +21,7 @@ For a simple setup example with configuration examples, have a look at the [Quic
 
 ```typescript
 import { trace } from '@opentelemetry/api'
-import { instrument, ResolveConfigFn } from '@microlabs/otel-cf-workers'
+import { instrument, ResolveConfigFn } from '@pydantic/otel-cf-workers'
 
 export interface Env {
 	HONEYCOMB_API_KEY: string
@@ -65,7 +65,7 @@ See the quick start code sample for an example of how it works.
 Instrumenting Durable Objects work very similar to the regular Worker auto-instrumentation. Instead of wrapping the handler in an `instrument` call, you wrap the Durable Object class with the `instrumentDO` function.
 
 ```typescript
-import { instrumentDO, PartialTraceConfig } from '@microlabs/otel-cf-workers'
+import { instrumentDO, PartialTraceConfig } from '@pydantic/otel-cf-workers'
 
 const config: ResolveConfigFn = (env: Env, _trigger) => {
 	return {
@@ -228,6 +228,12 @@ const tailSampler = (traceInfo: LocalTrace): boolean => {
 ```
 
 The default is a tailSampler that samples traces that have been head sampled or if the local root span is marked as an error.
+
+## OpenTelemetry Compatibility
+
+This package supports `@opentelemetry/api` `~1.9.x` as a peer dependency and is built against the current OpenTelemetry JS 2.x / experimental 0.x SDK packages.
+
+Unstable semantic convention keys are owned internally so consumers do not need to import `@opentelemetry/semantic-conventions/incubating`.
 
 #### Service
 

--- a/examples/quickstart/QUICKSTART_GUIDE.md
+++ b/examples/quickstart/QUICKSTART_GUIDE.md
@@ -8,7 +8,7 @@ You just need to provide your Honeycomb API key as a secret.
 ## Installation
 
 ```bash
-npm install @microlabs/otel-cf-workers @opentelemetry/api
+npm install @pydantic/otel-cf-workers @opentelemetry/api@^1.9.0
 npx wrangler secret put HONEYCOMB_API_KEY
 ```
 
@@ -18,7 +18,7 @@ in your `wrangler.toml`
 ## Example
 
 ```typescript
-import { instrument, ResolveConfigFn } from '@microlabs/otel-cf-workers'
+import { instrument, ResolveConfigFn } from '@pydantic/otel-cf-workers'
 import { trace } from '@opentelemetry/api'
 
 export interface Env {

--- a/examples/quickstart/package.json
+++ b/examples/quickstart/package.json
@@ -7,8 +7,8 @@
 		"deploy": "wrangler publish"
 	},
 	"dependencies": {
-		"@microlabs/otel-cf-workers": "^1.0.0-rc.45",
-		"@opentelemetry/api": "^1.6.0"
+		"@pydantic/otel-cf-workers": "^1.0.0-rc.54",
+		"@opentelemetry/api": "^1.9.0"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20231016.0",

--- a/examples/quickstart/src/index.ts
+++ b/examples/quickstart/src/index.ts
@@ -1,4 +1,4 @@
-import { instrument, ResolveConfigFn } from '@microlabs/otel-cf-workers'
+import { instrument, ResolveConfigFn } from '@pydantic/otel-cf-workers'
 import { trace } from '@opentelemetry/api'
 
 export interface Env {

--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
 	],
 	"homepage": "https://github.com/pydantic/otel-cf-workers#readme",
 	"dependencies": {
-		"@opentelemetry/core": "^2.0.0",
-		"@opentelemetry/exporter-trace-otlp-http": "^0.200.0",
-		"@opentelemetry/otlp-exporter-base": "^0.200.0",
-		"@opentelemetry/otlp-transformer": "^0.200.0",
-		"@opentelemetry/resources": "^2.0.0",
-		"@opentelemetry/sdk-trace-base": "^2.0.0",
-		"@opentelemetry/semantic-conventions": "^1.32.0"
+		"@opentelemetry/core": "^2.7.0",
+		"@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
+		"@opentelemetry/otlp-exporter-base": "^0.215.0",
+		"@opentelemetry/otlp-transformer": "^0.215.0",
+		"@opentelemetry/resources": "^2.7.0",
+		"@opentelemetry/sdk-trace-base": "^2.7.0",
+		"@opentelemetry/semantic-conventions": "^1.40.0"
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.27.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,26 +12,26 @@ importers:
         specifier: ~1.9.0
         version: 1.9.0
       '@opentelemetry/core':
-        specifier: ^2.0.0
-        version: 2.0.0(@opentelemetry/api@1.9.0)
+        specifier: ^2.7.0
+        version: 2.7.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/exporter-trace-otlp-http':
-        specifier: ^0.200.0
-        version: 0.200.0(@opentelemetry/api@1.9.0)
+        specifier: ^0.215.0
+        version: 0.215.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-exporter-base':
-        specifier: ^0.200.0
-        version: 0.200.0(@opentelemetry/api@1.9.0)
+        specifier: ^0.215.0
+        version: 0.215.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer':
-        specifier: ^0.200.0
-        version: 0.200.0(@opentelemetry/api@1.9.0)
+        specifier: ^0.215.0
+        version: 0.215.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources':
-        specifier: ^2.0.0
-        version: 2.0.0(@opentelemetry/api@1.9.0)
+        specifier: ^2.7.0
+        version: 2.7.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base':
-        specifier: ^2.0.0
-        version: 2.0.0(@opentelemetry/api@1.9.0)
+        specifier: ^2.7.0
+        version: 2.7.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions':
-        specifier: ^1.32.0
-        version: 1.32.0
+        specifier: ^1.40.0
+        version: 1.40.0
     devDependencies:
       '@changesets/cli':
         specifier: ^2.27.8
@@ -450,64 +450,64 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opentelemetry/api-logs@0.200.0':
-    resolution: {integrity: sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==}
+  '@opentelemetry/api-logs@0.215.0':
+    resolution: {integrity: sha512-xrFlqhdhUyO8wSRn6DjE0145/HPWSJ5Nm0C7vWua6TdL/FSEAZvEyvdsa9CRXuxo9ebb7j/NEPhEcO62IJ0qUA==}
     engines: {node: '>=8.0.0'}
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
-  '@opentelemetry/core@2.0.0':
-    resolution: {integrity: sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==}
+  '@opentelemetry/core@2.7.0':
+    resolution: {integrity: sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/exporter-trace-otlp-http@0.200.0':
-    resolution: {integrity: sha512-Goi//m/7ZHeUedxTGVmEzH19NgqJY+Bzr6zXo1Rni1+hwqaksEyJ44gdlEMREu6dzX1DlAaH/qSykSVzdrdafA==}
+  '@opentelemetry/exporter-trace-otlp-http@0.215.0':
+    resolution: {integrity: sha512-k4J9ISeGpb0Bm/wCrlcrbroMFTkiWMrdhNxQGrlktxLy127Yzd4/7nrTawn5d/ApktYTknvdixsE6++34Qfi1w==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/otlp-exporter-base@0.200.0':
-    resolution: {integrity: sha512-IxJgA3FD7q4V6gGq4bnmQM5nTIyMDkoGFGrBrrDjB6onEiq1pafma55V+bHvGYLWvcqbBbRfezr1GED88lacEQ==}
+  '@opentelemetry/otlp-exporter-base@0.215.0':
+    resolution: {integrity: sha512-lHrfbmeLSmesGSkkHiqDwOzfaEMSWXdc7q6UoLfbW8byONCb+bE/zkAr0kapN4US1baT/2nbpNT7Cn9XoB96Vg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/otlp-transformer@0.200.0':
-    resolution: {integrity: sha512-+9YDZbYybOnv7sWzebWOeK6gKyt2XE7iarSyBFkwwnP559pEevKOUD8NyDHhRjCSp13ybh9iVXlMfcj/DwF/yw==}
+  '@opentelemetry/otlp-transformer@0.215.0':
+    resolution: {integrity: sha512-cWwBvaV+vkXHkSoTYR8hGw+AW03UlgTr6xtrUKOMeum3T+8vffYXIfXu6KY5MLu8O9QtoBKqaKWw9I5xoOepng==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/resources@2.0.0':
-    resolution: {integrity: sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==}
+  '@opentelemetry/resources@2.7.0':
+    resolution: {integrity: sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/sdk-logs@0.200.0':
-    resolution: {integrity: sha512-VZG870063NLfObmQQNtCVcdXXLzI3vOjjrRENmU37HYiPFa0ZXpXVDsTD02Nh3AT3xYJzQaWKl2X2lQ2l7TWJA==}
+  '@opentelemetry/sdk-logs@0.215.0':
+    resolution: {integrity: sha512-y3ucOmphzc4vgBTyIGchs+N/1rkACmoka8QalT2z1LBNM232Z17zMYayHcMl+dgMoOadZ0b72UZv7mDtqy1cFA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
 
-  '@opentelemetry/sdk-metrics@2.0.0':
-    resolution: {integrity: sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA==}
+  '@opentelemetry/sdk-metrics@2.7.0':
+    resolution: {integrity: sha512-Vd7h95av/LYRsAVN7wbprvvJnHkq7swMXAo7Uad0Uxf9jl6NSReLa0JNivrcc5BVIx/vl2t+cgdVQQbnVhsR9w==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0 <1.10.0'
 
-  '@opentelemetry/sdk-trace-base@2.0.0':
-    resolution: {integrity: sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==}
+  '@opentelemetry/sdk-trace-base@2.7.0':
+    resolution: {integrity: sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/semantic-conventions@1.32.0':
-    resolution: {integrity: sha512-s0OpmpQFSfMrmedAn9Lhg4KWJELHCU6uU9dtIJ28N8UGhf9Y55im5X8fEzwhwDwiSqN+ZPSNrDJF7ivf/AuRPQ==}
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
     engines: {node: '>=14'}
 
   '@pkgjs/parseargs@0.11.0':
@@ -1569,8 +1569,8 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  protobufjs@7.5.0:
-    resolution: {integrity: sha512-Z2E/kOY1QjoMlCytmexzYfDm/w5fKAiRwpSzGtdnXW1zC88Z2yXazHHrOtwCzn+7wSxyE8PYM4rvVcMphF9sOA==}
+  protobufjs@8.0.1:
+    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
     engines: {node: '>=12.0.0'}
 
   pseudomap@1.0.2:
@@ -2363,70 +2363,71 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@opentelemetry/api-logs@0.200.0':
+  '@opentelemetry/api-logs@0.215.0':
     dependencies:
       '@opentelemetry/api': 1.9.0
 
   '@opentelemetry/api@1.9.0': {}
 
-  '@opentelemetry/core@2.0.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/semantic-conventions': 1.32.0
+      '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/exporter-trace-otlp-http@0.200.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/exporter-trace-otlp-http@0.215.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.0.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.200.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.200.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.0.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.0.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.215.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.215.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.0)
 
-  '@opentelemetry/otlp-exporter-base@0.200.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/otlp-exporter-base@0.215.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.0.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.200.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.215.0(@opentelemetry/api@1.9.0)
 
-  '@opentelemetry/otlp-transformer@0.200.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/otlp-transformer@0.215.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.200.0
-      '@opentelemetry/core': 2.0.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.0.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.200.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.0.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.0.0(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.0
+      '@opentelemetry/api-logs': 0.215.0
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.215.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.7.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.0)
+      protobufjs: 8.0.1
 
-  '@opentelemetry/resources@2.0.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.0.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.32.0
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/sdk-logs@0.200.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/sdk-logs@0.215.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.200.0
-      '@opentelemetry/core': 2.0.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.0.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api-logs': 0.215.0
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/sdk-metrics@2.0.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/sdk-metrics@2.7.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.0.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.0.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.0)
 
-  '@opentelemetry/sdk-trace-base@2.0.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.0.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.0.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.32.0
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/semantic-conventions@1.32.0': {}
+  '@opentelemetry/semantic-conventions@1.40.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -3513,7 +3514,7 @@ snapshots:
 
   prettier@3.3.3: {}
 
-  protobufjs@7.5.0:
+  protobufjs@8.0.1:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2

--- a/src/instrumentation/analytics-engine.ts
+++ b/src/instrumentation/analytics-engine.ts
@@ -3,8 +3,8 @@ import {
 	ATTR_DB_NAMESPACE,
 	ATTR_DB_OPERATION_NAME,
 	ATTR_DB_QUERY_TEXT,
-	ATTR_DB_SYSTEM,
-} from '@opentelemetry/semantic-conventions/incubating'
+	ATTR_DB_SYSTEM_NAME,
+} from '@opentelemetry/semantic-conventions'
 import { wrap } from '../wrap.js'
 
 type ExtraAttributeFn = (argArray: any[], result: any) => Attributes
@@ -32,7 +32,7 @@ function instrumentAEFn(fn: Function, name: string, operation: string) {
 			const attributes = {
 				binding_type: 'AnalyticsEngine',
 				[ATTR_DB_NAMESPACE]: name,
-				[ATTR_DB_SYSTEM]: dbSystem,
+				[ATTR_DB_SYSTEM_NAME]: dbSystem,
 				[ATTR_DB_OPERATION_NAME]: operation,
 			}
 			const options: SpanOptions = {

--- a/src/instrumentation/d1.ts
+++ b/src/instrumentation/d1.ts
@@ -3,8 +3,8 @@ import {
 	ATTR_DB_NAMESPACE,
 	ATTR_DB_OPERATION_NAME,
 	ATTR_DB_QUERY_TEXT,
-	ATTR_DB_SYSTEM,
-} from '@opentelemetry/semantic-conventions/incubating'
+	ATTR_DB_SYSTEM_NAME,
+} from '@opentelemetry/semantic-conventions'
 import { wrap } from '../wrap.js'
 
 const dbSystem = 'Cloudflare D1'
@@ -31,7 +31,7 @@ function spanOptions(dbName: string, operation: string, sql?: string): SpanOptio
 	const attributes: Attributes = {
 		binding_type: 'D1',
 		[ATTR_DB_NAMESPACE]: dbName,
-		[ATTR_DB_SYSTEM]: dbSystem,
+		[ATTR_DB_SYSTEM_NAME]: dbSystem,
 		[ATTR_DB_OPERATION_NAME]: operation,
 	}
 	if (sql) {

--- a/src/instrumentation/do-storage.ts
+++ b/src/instrumentation/do-storage.ts
@@ -1,9 +1,5 @@
 import { Attributes, SpanKind, SpanOptions, trace } from '@opentelemetry/api'
-import {
-	ATTR_DB_OPERATION_NAME,
-	ATTR_DB_QUERY_TEXT,
-	ATTR_DB_SYSTEM,
-} from '@opentelemetry/semantic-conventions/incubating'
+import { ATTR_DB_OPERATION_NAME, ATTR_DB_QUERY_TEXT, ATTR_DB_SYSTEM_NAME } from '@opentelemetry/semantic-conventions'
 import { wrap } from '../wrap.js'
 import { Overloads } from './common.js'
 
@@ -169,7 +165,7 @@ function instrumentStorageFn(fn: Function, operation: string) {
 	const fnHandler: ProxyHandler<any> = {
 		apply: (target, thisArg, argArray) => {
 			const attributes = {
-				[ATTR_DB_SYSTEM]: dbSystem,
+				[ATTR_DB_SYSTEM_NAME]: dbSystem,
 				[ATTR_DB_OPERATION_NAME]: operation,
 				[ATTR_DB_QUERY_TEXT]: `${operation} ${argArray[0]}`,
 			}

--- a/src/instrumentation/do.ts
+++ b/src/instrumentation/do.ts
@@ -1,6 +1,6 @@
 import { context as api_context, Exception, SpanKind, SpanOptions, SpanStatusCode, trace } from '@opentelemetry/api'
-import { ATTR_FAAS_COLDSTART, ATTR_FAAS_TRIGGER } from '@opentelemetry/semantic-conventions/incubating'
 import { Initialiser, setConfig } from '../config.js'
+import { ATTR_FAAS_COLDSTART, ATTR_FAAS_TRIGGER } from '../semconv.js'
 import { DOConstructorTrigger } from '../types.js'
 import { passthroughGet, unwrap, wrap } from '../wrap.js'
 import { exportSpans } from './common.js'

--- a/src/instrumentation/email.ts
+++ b/src/instrumentation/email.ts
@@ -1,14 +1,10 @@
 import { setConfig, type Initialiser } from '../config'
+import { ATTR_FAAS_TRIGGER, ATTR_MESSAGING_DESTINATION_NAME, ATTR_RPC_MESSAGE_ID } from '../semconv.js'
 import { wrap } from '../wrap'
 import { exportSpans, proxyExecutionContext } from './common'
 import { context as api_context, Exception, SpanKind, type SpanOptions, trace } from '@opentelemetry/api'
 import { instrumentEnv } from './env'
 import { versionAttributes } from './version'
-import {
-	ATTR_FAAS_TRIGGER,
-	ATTR_MESSAGING_DESTINATION_NAME,
-	ATTR_RPC_MESSAGE_ID,
-} from '@opentelemetry/semantic-conventions/incubating'
 
 type EmailHandler = EmailExportedHandler
 export type EmailHandlerArgs = Parameters<EmailHandler>

--- a/src/instrumentation/fetch.ts
+++ b/src/instrumentation/fetch.ts
@@ -15,6 +15,7 @@ import { instrumentEnv } from './env.js'
 import { exportSpans, proxyExecutionContext } from './common.js'
 import { ResolvedTraceConfig } from '../types.js'
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base'
+import { ATTR_FAAS_COLDSTART, ATTR_FAAS_INVOCATION_ID, ATTR_FAAS_TRIGGER } from '../semconv.js'
 import { versionAttributes } from './version.js'
 
 export type IncludeTraceContextFn = (request: Request) => boolean
@@ -147,9 +148,9 @@ export function executeFetchHandler(fetchFn: FetchHandler, [request, env, ctx]: 
 
 	const tracer = trace.getTracer('fetchHandler')
 	const attributes = {
-		['faas.trigger']: 'http',
-		['faas.coldstart']: cold_start,
-		['faas.invocation_id']: request.headers.get('cf-ray') ?? undefined,
+		[ATTR_FAAS_TRIGGER]: 'http',
+		[ATTR_FAAS_COLDSTART]: cold_start,
+		[ATTR_FAAS_INVOCATION_ID]: request.headers.get('cf-ray') ?? undefined,
 	}
 	cold_start = false
 	Object.assign(attributes, gatherRequestAttributes(request))

--- a/src/instrumentation/kv.ts
+++ b/src/instrumentation/kv.ts
@@ -3,8 +3,8 @@ import {
 	ATTR_DB_NAMESPACE,
 	ATTR_DB_OPERATION_NAME,
 	ATTR_DB_QUERY_TEXT,
-	ATTR_DB_SYSTEM,
-} from '@opentelemetry/semantic-conventions/incubating'
+	ATTR_DB_SYSTEM_NAME,
+} from '@opentelemetry/semantic-conventions'
 import { wrap } from '../wrap.js'
 
 type ExtraAttributeFn = (argArray: any[], result: any) => Attributes
@@ -78,7 +78,7 @@ function instrumentKVFn(fn: Function, name: string, operation: string) {
 			const attributes = {
 				binding_type: 'KV',
 				[ATTR_DB_NAMESPACE]: name,
-				[ATTR_DB_SYSTEM]: dbSystem,
+				[ATTR_DB_SYSTEM_NAME]: dbSystem,
 				[ATTR_DB_OPERATION_NAME]: operation,
 			}
 			const options: SpanOptions = {

--- a/src/instrumentation/queue.ts
+++ b/src/instrumentation/queue.ts
@@ -1,6 +1,6 @@
 import { Attributes, Exception, SpanKind, SpanOptions, context as api_context, trace } from '@opentelemetry/api'
-import { ATTR_FAAS_TRIGGER } from '@opentelemetry/semantic-conventions/incubating'
 import { Initialiser, setConfig } from '../config.js'
+import { ATTR_FAAS_TRIGGER } from '../semconv.js'
 import { unwrap, wrap } from '../wrap.js'
 import { exportSpans, proxyExecutionContext } from './common.js'
 import { instrumentEnv } from './env.js'

--- a/src/instrumentation/scheduled.ts
+++ b/src/instrumentation/scheduled.ts
@@ -3,13 +3,8 @@ import { Initialiser, setConfig } from '../config.js'
 import { exportSpans, proxyExecutionContext } from './common.js'
 import { instrumentEnv } from './env.js'
 import { wrap } from '../wrap.js'
+import { ATTR_FAAS_COLDSTART, ATTR_FAAS_CRON, ATTR_FAAS_TIME, ATTR_FAAS_TRIGGER } from '../semconv.js'
 import { versionAttributes } from './version.js'
-import {
-	ATTR_FAAS_COLDSTART,
-	ATTR_FAAS_CRON,
-	ATTR_FAAS_TIME,
-	ATTR_FAAS_TRIGGER,
-} from '@opentelemetry/semantic-conventions/incubating'
 
 type ScheduledHandler = ExportedHandlerScheduledHandler<unknown>
 export type ScheduledHandlerArgs = Parameters<ScheduledHandler>

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -14,17 +14,14 @@ import { createScheduledHandler } from './instrumentation/scheduled.js'
 import * as versions from '../versions.json'
 import { createEmailHandler } from './instrumentation/email.js'
 import {
+	ATTR_SERVICE_NAME,
+	ATTR_SERVICE_NAMESPACE,
+	ATTR_SERVICE_VERSION,
 	ATTR_TELEMETRY_SDK_LANGUAGE,
 	ATTR_TELEMETRY_SDK_NAME,
 	ATTR_TELEMETRY_SDK_VERSION,
 } from '@opentelemetry/semantic-conventions'
-import {
-	ATTR_DEPLOYMENT_ENVIRONMENT_NAME,
-	ATTR_FAAS_MAX_MEMORY,
-	ATTR_SERVICE_NAME,
-	ATTR_SERVICE_NAMESPACE,
-	ATTR_SERVICE_VERSION,
-} from '@opentelemetry/semantic-conventions/incubating'
+import { ATTR_DEPLOYMENT_ENVIRONMENT_NAME, ATTR_FAAS_MAX_MEMORY } from './semconv.js'
 
 type FetchHandler = ExportedHandlerFetchHandler<unknown, unknown>
 type ScheduledHandler = ExportedHandlerScheduledHandler<unknown>

--- a/src/semconv.ts
+++ b/src/semconv.ts
@@ -1,0 +1,11 @@
+// Own unstable and compatibility-only semantic convention keys locally so
+// runtime code does not depend on the incubating semconv entrypoint.
+export const ATTR_DEPLOYMENT_ENVIRONMENT_NAME = 'deployment.environment.name' as const
+export const ATTR_FAAS_COLDSTART = 'faas.coldstart' as const
+export const ATTR_FAAS_CRON = 'faas.cron' as const
+export const ATTR_FAAS_INVOCATION_ID = 'faas.invocation_id' as const
+export const ATTR_FAAS_MAX_MEMORY = 'faas.max_memory' as const
+export const ATTR_FAAS_TIME = 'faas.time' as const
+export const ATTR_FAAS_TRIGGER = 'faas.trigger' as const
+export const ATTR_MESSAGING_DESTINATION_NAME = 'messaging.destination.name' as const
+export const ATTR_RPC_MESSAGE_ID = 'rpc.message.id' as const

--- a/test/instrumentation/do-storage.test.ts
+++ b/test/instrumentation/do-storage.test.ts
@@ -63,7 +63,7 @@ describe('delete', () => {
 			  "db.cf.do.key": "key",
 			  "db.operation.name": "delete",
 			  "db.query.text": "delete key",
-			  "db.system": "Cloudflare DO",
+			  "db.system.name": "Cloudflare DO",
 			  "operation": "delete",
 			}
 		`)
@@ -86,7 +86,7 @@ describe('delete', () => {
 			  "db.cf.do.number_of_keys": 2,
 			  "db.operation.name": "delete",
 			  "db.query.text": "delete key1,key2",
-			  "db.system": "Cloudflare DO",
+			  "db.system.name": "Cloudflare DO",
 			  "operation": "delete",
 			}
 		`)
@@ -110,7 +110,7 @@ describe('delete', () => {
 			  "db.cf.do.no_cache": true,
 			  "db.operation.name": "delete",
 			  "db.query.text": "delete key",
-			  "db.system": "Cloudflare DO",
+			  "db.system.name": "Cloudflare DO",
 			  "operation": "delete",
 			}
 		`)
@@ -145,7 +145,7 @@ describe('deleteAll', () => {
 			  "db.cf.do.has_result": false,
 			  "db.operation.name": "deleteAll",
 			  "db.query.text": "deleteAll undefined",
-			  "db.system": "Cloudflare DO",
+			  "db.system.name": "Cloudflare DO",
 			  "operation": "deleteAll",
 			}
 		`)
@@ -192,7 +192,7 @@ describe('get', () => {
 			  "db.cf.do.key": "key",
 			  "db.operation.name": "get",
 			  "db.query.text": "get key",
-			  "db.system": "Cloudflare DO",
+			  "db.system.name": "Cloudflare DO",
 			  "operation": "get",
 			}
 		`)
@@ -215,7 +215,7 @@ describe('get', () => {
 			  "db.cf.do.number_of_keys": 2,
 			  "db.operation.name": "get",
 			  "db.query.text": "get key1,key2",
-			  "db.system": "Cloudflare DO",
+			  "db.system.name": "Cloudflare DO",
 			  "operation": "get",
 			}
 		`)
@@ -239,7 +239,7 @@ describe('get', () => {
 			  "db.cf.do.no_cache": true,
 			  "db.operation.name": "get",
 			  "db.query.text": "get key",
-			  "db.system": "Cloudflare DO",
+			  "db.system.name": "Cloudflare DO",
 			  "operation": "get",
 			}
 		`)
@@ -282,7 +282,7 @@ describe('list', () => {
 			  "db.cf.do.number_of_results": 0,
 			  "db.operation.name": "list",
 			  "db.query.text": "list undefined",
-			  "db.system": "Cloudflare DO",
+			  "db.system.name": "Cloudflare DO",
 			  "operation": "list",
 			}
 		`)
@@ -305,7 +305,7 @@ describe('list', () => {
 			  "db.cf.do.number_of_results": 0,
 			  "db.operation.name": "list",
 			  "db.query.text": "list [object Object]",
-			  "db.system": "Cloudflare DO",
+			  "db.system.name": "Cloudflare DO",
 			  "operation": "list",
 			}
 		`)
@@ -345,7 +345,7 @@ describe('put', () => {
 			  "db.cf.do.key": "key",
 			  "db.operation.name": "put",
 			  "db.query.text": "put key",
-			  "db.system": "Cloudflare DO",
+			  "db.system.name": "Cloudflare DO",
 			  "operation": "put",
 			}
 		`)
@@ -374,7 +374,7 @@ describe('put', () => {
 			  "db.cf.do.no_cache": true,
 			  "db.operation.name": "put",
 			  "db.query.text": "put key",
-			  "db.system": "Cloudflare DO",
+			  "db.system.name": "Cloudflare DO",
 			  "operation": "put",
 			}
 		`)
@@ -400,7 +400,7 @@ describe('put', () => {
 			  "db.cf.do.number_of_keys": 2,
 			  "db.operation.name": "put",
 			  "db.query.text": "put [object Object]",
-			  "db.system": "Cloudflare DO",
+			  "db.system.name": "Cloudflare DO",
 			  "operation": "put",
 			}
 		`)
@@ -436,7 +436,7 @@ describe('put', () => {
 			  "db.cf.do.number_of_keys": 2,
 			  "db.operation.name": "put",
 			  "db.query.text": "put [object Object]",
-			  "db.system": "Cloudflare DO",
+			  "db.system.name": "Cloudflare DO",
 			  "operation": "put",
 			}
 		`)
@@ -474,7 +474,7 @@ test('sync', async () => {
 		  "db.cf.do.has_result": false,
 		  "db.operation.name": "sync",
 		  "db.query.text": "sync undefined",
-		  "db.system": "Cloudflare DO",
+		  "db.system.name": "Cloudflare DO",
 		  "operation": "sync",
 		}
 	`)


### PR DESCRIPTION
## Summary
- upgrade the OpenTelemetry JS dependencies to current releases
- move unstable semconv usage behind a local compatibility boundary and stop importing the incubating entrypoint at runtime
- migrate emitted database telemetry from `db.system` to `db.system.name`, keeping the existing Cloudflare-specific values
- update quickstart/docs and add a minor changeset for the RC release

## Validation
- pnpm install
- pnpm build
- pnpm exec tsc --noEmit
- pnpm test
- pnpm pack